### PR TITLE
StatusOnly components added

### DIFF
--- a/dist/BaseInput.js
+++ b/dist/BaseInput.js
@@ -73,7 +73,8 @@ var BaseInput = function BaseInput(_ref) {
       clear = _ref.clear,
       onBlur = _ref.onBlur,
       onClear = _ref.onClear,
-      disabled = _ref.disabled;
+      disabled = _ref.disabled,
+      statusOnly = _ref.statusOnly;
   var classes = useStyles();
 
   var selectLabel = function selectLabel() {
@@ -87,6 +88,24 @@ var BaseInput = function BaseInput(_ref) {
     } else {
       if ((0, _utils.isTextLong)(label)) return _utils.defaultPlaceHolder;
       return label;
+    }
+  };
+
+  var selectAdorment = function selectAdorment() {
+    if (clear && !disabled) {
+      return _react.default.createElement(_core.InputAdornment, {
+        position: "end"
+      }, _react.default.createElement(_core.IconButton, {
+        "aria-label": "clear input",
+        onClick: onClear,
+        tabIndex: "-1"
+      }, _react.default.createElement(_icons.Clear
+      /*className={classes.icon}*/
+      , null)));
+    } else if (disabled && statusOnly) {
+      return _react.default.createElement(_core.InputAdornment, {
+        position: "end"
+      }, _react.default.createElement("h3", null, "Cargado"));
     }
   };
 
@@ -111,15 +130,7 @@ var BaseInput = function BaseInput(_ref) {
     value: value,
     onChange: handleChange,
     onBlur: onBlur,
-    endAdornment: clear && !disabled && _react.default.createElement(_core.InputAdornment, {
-      position: "end"
-    }, _react.default.createElement(_core.IconButton, {
-      "aria-label": "clear input",
-      onClick: onClear,
-      tabIndex: "-1"
-    }, _react.default.createElement(_icons.Clear
-    /*className={classes.icon}*/
-    , null))),
+    endAdornment: selectAdorment(),
     inputProps: {
       className: classes.input
     },
@@ -141,7 +152,8 @@ BaseInput.defaultProps = {
   type: 'text',
   clear: true,
   errorMessage: '',
-  disabled: false
+  disabled: false,
+  statusOnly: false
 };
 BaseInput.propTypes = {
   label: _propTypes.default.string.isRequired,
@@ -153,7 +165,8 @@ BaseInput.propTypes = {
   errorMessage: _propTypes.default.string,
   handleChange: _propTypes.default.func.isRequired,
   onBlur: _propTypes.default.func,
-  disabled: _propTypes.default.bool
+  disabled: _propTypes.default.bool,
+  status: _propTypes.default.bool
 };
 var _default = BaseInput;
 exports.default = _default;

--- a/dist/nodes/BaseInput/index.js
+++ b/dist/nodes/BaseInput/index.js
@@ -37,6 +37,12 @@ function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = 
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
+var STATUS = {
+  'Rechazado': '#C25B5B',
+  'Cargado': '#5BC2C2',
+  'Pendiente': '#C1C1C1'
+};
+
 var BaseInput = function BaseInput(_ref) {
   var label = _ref.label,
       value = _ref.value,
@@ -49,7 +55,9 @@ var BaseInput = function BaseInput(_ref) {
       clear = _ref.clear,
       onBlur = _ref.onBlur,
       onClear = _ref.onClear,
-      maxLength = _ref.maxLength;
+      maxLength = _ref.maxLength,
+      statusOnly = _ref.statusOnly,
+      status = _ref.status;
   var classes = (0, _style.default)();
 
   var _React$useState = _react.default.useState(0),
@@ -74,6 +82,28 @@ var BaseInput = function BaseInput(_ref) {
     } else {
       if ((0, _utils.isTextLong)(label)) return _utils.defaultPlaceHolder;
       return label;
+    }
+  };
+
+  var selectAdorment = function selectAdorment() {
+    if (clear && value && !disabled) {
+      return _react.default.createElement(_core.InputAdornment, {
+        position: "end"
+      }, _react.default.createElement(_core.IconButton, {
+        "aria-label": "clear input",
+        onClick: onClear,
+        tabIndex: "-1"
+      }, _react.default.createElement(_icons.Clear
+      /*className={classes.icon}*/
+      , null)));
+    } else if (disabled && statusOnly) {
+      return _react.default.createElement(_core.InputAdornment, {
+        position: "end"
+      }, _react.default.createElement("h3", {
+        style: {
+          color: STATUS[status]
+        }
+      }, status));
     }
   };
 
@@ -104,15 +134,7 @@ var BaseInput = function BaseInput(_ref) {
     inputProps: _objectSpread2({}, maxLength ? {
       maxLength: maxLength
     } : {}),
-    endAdornment: clear && value && !disabled && _react.default.createElement(_core.InputAdornment, {
-      position: "end"
-    }, _react.default.createElement(_core.IconButton, {
-      "aria-label": "clear input",
-      onClick: onClear,
-      tabIndex: "-1"
-    }, _react.default.createElement(_icons.Clear, {
-      className: classes.icon
-    }))),
+    endAdornment: selectAdorment(),
     classes: {
       notchedOutline: classes.notchedOutline,
       focused: classes.focusNotchedOutline
@@ -131,7 +153,9 @@ BaseInput.defaultProps = {
   type: 'text',
   clear: true,
   errorMessage: '',
-  disabled: false
+  disabled: false,
+  statusOnly: false,
+  status: ''
 };
 BaseInput.propTypes = {
   label: _propTypes.default.string.isRequired,
@@ -143,7 +167,9 @@ BaseInput.propTypes = {
   clear: _propTypes.default.bool,
   errorMessage: _propTypes.default.string,
   handleChange: _propTypes.default.func.isRequired,
-  onBlur: _propTypes.default.func
+  onBlur: _propTypes.default.func,
+  statusOnly: _propTypes.default.bool,
+  status: _propTypes.default.string
 };
 var _default = BaseInput;
 exports.default = _default;

--- a/dist/nodes/BaseStatusOnlyInput/index.js
+++ b/dist/nodes/BaseStatusOnlyInput/index.js
@@ -1,0 +1,35 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _BaseInput = _interopRequireDefault(require("../BaseInput"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var BaseStatusOnlyInput = function BaseStatusOnlyInput(_ref) {
+  var label = _ref.label,
+      statusOnly = _ref.statusOnly,
+      status = _ref.status;
+  return _react.default.createElement(_BaseInput.default, {
+    handleChange: function handleChange() {},
+    label: label,
+    disabled: true,
+    statusOnly: statusOnly,
+    status: status
+  });
+};
+
+BaseStatusOnlyInput.propTypes = {
+  label: _propTypes.default.string.isRequired,
+  statusOnly: _propTypes.default.bool.isRequired,
+  status: _propTypes.default.string.isRequired
+};
+var _default = BaseStatusOnlyInput;
+exports.default = _default;

--- a/dist/nodes/CardApp/index.js
+++ b/dist/nodes/CardApp/index.js
@@ -47,13 +47,13 @@ CardApp.defaultProps = {
   title: 'FORMAS',
   count: 23,
   onClick: function onClick() {},
-  Icon: 'https://fintecimal-test.s3.amazonaws.com/fintecimal-img/stepconfigs-icons/verificacion-general.png'
+  Icon: _DescriptionOutlined.default
 };
 CardApp.propTypes = {
   title: _propTypes.default.string,
   count: _propTypes.default.number,
   onClick: _propTypes.default.func,
-  Icon: _propTypes.default.object || _propTypes.default.string
+  Icon: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.object])
 };
 var _default = CardApp;
 exports.default = _default;

--- a/dist/nodes/CardApp/style.js
+++ b/dist/nodes/CardApp/style.js
@@ -47,7 +47,7 @@ var useStyles = (0, _styles.makeStyles)(function (theme) {
       fontSize: 50
     },
     image: {
-      width: '100px'
+      width: '80px'
     }
   };
 });

--- a/dist/nodes/StatusOnlyDocument/index.js
+++ b/dist/nodes/StatusOnlyDocument/index.js
@@ -1,0 +1,43 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _style = _interopRequireDefault(require("./style"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var STATUS = {
+  Rechazado: '#C25B5B',
+  Cargado: '#5BC2C2',
+  Pendiente: '#C1C1C1'
+};
+
+var StatusOnlyDocument = function StatusOnlyDocument(_ref) {
+  var label = _ref.label,
+      status = _ref.status;
+  var classes = (0, _style.default)();
+  return _react.default.createElement("div", {
+    className: classes.header
+  }, _react.default.createElement("p", {
+    className: classes.label
+  }, label), _react.default.createElement("p", {
+    style: {
+      color: STATUS[status]
+    },
+    className: classes.status
+  }, status));
+};
+
+StatusOnlyDocument.propTypes = {
+  label: _propTypes.default.string.isRequired,
+  status: _propTypes.default.string.isRequired
+};
+var _default = StatusOnlyDocument;
+exports.default = _default;

--- a/dist/nodes/StatusOnlyDocument/style.js
+++ b/dist/nodes/StatusOnlyDocument/style.js
@@ -1,0 +1,47 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _styles = require("@material-ui/core/styles");
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var _default = (0, _styles.makeStyles)(function (theme) {
+  return {
+    header: _defineProperty({
+      display: 'flex',
+      flexWrap: 'wrap',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingTop: theme.spacing(0.5),
+      paddingBottom: theme.spacing(2.5),
+      borderBottom: '1px solid #DCDCDC',
+      margin: 0,
+      marginRight: theme.spacing(3),
+      marginLeft: theme.spacing(3)
+    }, theme.breakpoints.down('sm'), {
+      marginRight: 0,
+      marginLeft: 0
+    }),
+    label: {
+      fontFamily: 'Open Sans',
+      fontSize: '1rem',
+      lineHeight: '1.25rem',
+      fontWeight: '700',
+      color: '#000',
+      margin: 0
+    },
+    status: {
+      fontFamily: 'Open Sans',
+      fontSize: '1rem',
+      lineHeight: '1.25rem',
+      fontWeight: '700',
+      margin: 0
+    }
+  };
+});
+
+exports.default = _default;

--- a/src/lib/BaseInput.js
+++ b/src/lib/BaseInput.js
@@ -62,7 +62,8 @@ const BaseInput = ({
   clear,
   onBlur,
   onClear,
-  disabled
+  disabled,
+  statusOnly
 }) => {
   const classes = useStyles();
   const selectLabel = () => {
@@ -77,6 +78,24 @@ const BaseInput = ({
       return label;
     }
   };
+  const selectAdorment = () => {
+    if (clear && !disabled) {
+      return (
+        <InputAdornment position="end">
+            <IconButton aria-label="clear input" onClick={onClear} tabIndex="-1">
+                <Clear /*className={classes.icon}*/ />
+            </IconButton>
+        </InputAdornment>
+      );
+    } else if(disabled && statusOnly) {
+      return (
+        <InputAdornment position="end">
+            <h3>Cargado</h3>
+        </InputAdornment>
+      );
+    }
+  };
+
   return (
     <div className={classes.root}>
       {isTextLong(label) && (
@@ -100,16 +119,7 @@ const BaseInput = ({
           value={value}
           onChange={handleChange}
           onBlur={onBlur}
-          endAdornment={
-            clear &&
-            !disabled && (
-              <InputAdornment position="end">
-                <IconButton aria-label="clear input" onClick={onClear} tabIndex="-1">
-                  <Clear /*className={classes.icon}*/ />
-                </IconButton>
-              </InputAdornment>
-            )
-          }
+          endAdornment={selectAdorment()}
           inputProps={{
             className: classes.input
           }}
@@ -133,7 +143,8 @@ BaseInput.defaultProps = {
   type: 'text',
   clear: true,
   errorMessage: '',
-  disabled: false
+  disabled: false,
+  statusOnly: false,
 };
 
 BaseInput.propTypes = {
@@ -146,7 +157,8 @@ BaseInput.propTypes = {
   errorMessage: PropTypes.string,
   handleChange: PropTypes.func.isRequired,
   onBlur: PropTypes.func,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  status: PropTypes.bool,
 };
 
 export default BaseInput;

--- a/src/lib/nodes/BaseInput/index.jsx
+++ b/src/lib/nodes/BaseInput/index.jsx
@@ -14,6 +14,12 @@ import { isTextLong, defaultPlaceHolder } from '../../commons/utils';
 import useStyles from './style';
 import '../../styles/BaseInput.css';
 
+const STATUS ={
+  'Rechazado': '#C25B5B',
+  'Cargado': '#5BC2C2',
+  'Pendiente': '#C1C1C1',
+};
+
 const BaseInput = ({
   label,
   value,
@@ -27,6 +33,8 @@ const BaseInput = ({
   onBlur,
   onClear,
   maxLength,
+  statusOnly,
+  status,
 }) => {
   const classes = useStyles();
   const [labelWidth, setLabelWidth] = React.useState(0);
@@ -45,6 +53,24 @@ const BaseInput = ({
     } else {
       if (isTextLong(label)) return defaultPlaceHolder;
       return label;
+    }
+  };
+
+  const selectAdorment = () => {
+    if (clear && value && !disabled) {
+      return (
+        <InputAdornment position="end">
+            <IconButton aria-label="clear input" onClick={onClear} tabIndex="-1">
+                <Clear /*className={classes.icon}*/ />
+            </IconButton>
+        </InputAdornment>
+      );
+    } else if(disabled && statusOnly) {
+      return (
+        <InputAdornment position="end">
+            <h3 style={{ color: STATUS[status] }}>{status}</h3>
+        </InputAdornment>
+      );
     }
   };
 
@@ -77,17 +103,7 @@ const BaseInput = ({
           inputProps={{
             ...(maxLength ? { maxLength } : {}),
           }}
-          endAdornment={
-            clear &&
-            value &&
-            !disabled && (
-              <InputAdornment position="end">
-                <IconButton aria-label="clear input" onClick={onClear} tabIndex="-1">
-                  <Clear className={classes.icon} />
-                </IconButton>
-              </InputAdornment>
-            )
-          }
+          endAdornment={selectAdorment()}
           classes={{
             notchedOutline: classes.notchedOutline,
             focused: classes.focusNotchedOutline
@@ -108,7 +124,9 @@ BaseInput.defaultProps = {
   type: 'text',
   clear: true,
   errorMessage: '',
-  disabled: false
+  disabled: false,
+  statusOnly: false,
+  status: '',
 };
 
 BaseInput.propTypes = {
@@ -121,7 +139,9 @@ BaseInput.propTypes = {
   clear: PropTypes.bool,
   errorMessage: PropTypes.string,
   handleChange: PropTypes.func.isRequired,
-  onBlur: PropTypes.func
+  onBlur: PropTypes.func,
+  statusOnly: PropTypes.bool,
+  status: PropTypes.string,
 };
 
 export default BaseInput;

--- a/src/lib/nodes/BaseStatusOnlyInput/index.jsx
+++ b/src/lib/nodes/BaseStatusOnlyInput/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import BaseInput from '../BaseInput';
+
+const BaseStatusOnlyInput = ({
+  label, statusOnly, status,
+}) => (
+  <BaseInput
+    handleChange={() => {}}
+    label={label}
+    disabled
+    statusOnly={statusOnly}
+    status={status}
+  />
+);
+
+BaseStatusOnlyInput.propTypes = {
+  label: PropTypes.string.isRequired,
+  statusOnly: PropTypes.bool.isRequired,
+  status: PropTypes.string.isRequired,
+};
+
+export default BaseStatusOnlyInput;

--- a/src/lib/nodes/CardApp/index.jsx
+++ b/src/lib/nodes/CardApp/index.jsx
@@ -20,14 +20,17 @@ CardApp.defaultProps = {
   title: 'FORMAS',
   count: 23,
   onClick: () => {},
-  Icon: 'https://fintecimal-test.s3.amazonaws.com/fintecimal-img/stepconfigs-icons/verificacion-general.png'
+  Icon: DescriptionOutlinedIcon,
 };
 
 CardApp.propTypes = {
   title: PropTypes.string,
   count: PropTypes.number,
   onClick: PropTypes.func,
-  Icon: PropTypes.object || PropTypes.string,
+  Icon: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]),
 };
 
 export default CardApp;

--- a/src/lib/nodes/CardApp/style.js
+++ b/src/lib/nodes/CardApp/style.js
@@ -39,7 +39,7 @@ const useStyles = makeStyles(theme => ({
     fontSize: 50
   },
   image: {
-    width: '100px',
+    width: '80px',
   },
 }));
 

--- a/src/lib/nodes/StatusOnlyDocument/index.jsx
+++ b/src/lib/nodes/StatusOnlyDocument/index.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import useStyles from './style';
+
+const STATUS = {
+  Rechazado: '#C25B5B',
+  Cargado: '#5BC2C2',
+  Pendiente: '#C1C1C1',
+};
+
+const StatusOnlyDocument = ({ label, status }) => {
+  const classes = useStyles();
+  return (
+    <div className={classes.header}>
+      <p className={classes.label}>{label}</p>
+      <p style={{ color: STATUS[status] }} className={classes.status}>{status}</p>
+    </div>
+  );
+};
+
+StatusOnlyDocument.propTypes = {
+  label: PropTypes.string.isRequired,
+  status: PropTypes.string.isRequired,
+};
+
+export default StatusOnlyDocument;

--- a/src/lib/nodes/StatusOnlyDocument/style.js
+++ b/src/lib/nodes/StatusOnlyDocument/style.js
@@ -1,0 +1,35 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export default makeStyles((theme) => ({
+  header: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(2.5),
+    borderBottom: '1px solid #DCDCDC',
+    margin: 0,
+    marginRight: theme.spacing(3),
+    marginLeft: theme.spacing(3),
+    [theme.breakpoints.down('sm')]: {
+      marginRight: 0,
+      marginLeft: 0,
+    },
+  },
+  label: {
+    fontFamily: 'Open Sans',
+    fontSize: '1rem',
+    lineHeight: '1.25rem',
+    fontWeight: '700',
+    color: '#000',
+    margin: 0,
+  },
+  status: {
+    fontFamily: 'Open Sans',
+    fontSize: '1rem',
+    lineHeight: '1.25rem',
+    fontWeight: '700',
+    margin: 0,
+  },
+}));


### PR DESCRIPTION
### Description
- New component to show the state of documents and fields without information.
- Icon in CardApp reduced.

Fixes # [ISSUE]

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Local.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 

<img width="947" alt="Documentos" src="https://user-images.githubusercontent.com/79170332/133479751-491badd8-a960-4716-9a7d-12750f04f4b5.png">

<img width="898" alt="Datos" src="https://user-images.githubusercontent.com/79170332/133479776-4ab6a1a7-36eb-4e83-965d-fe91bc13e839.png">

