### PR TITLE
fixing padding in search icon button

### DIFF
--- a/dist/nodes/SearchBar/index.js
+++ b/dist/nodes/SearchBar/index.js
@@ -79,6 +79,7 @@ var Search = function Search(_ref) {
       position: "end"
     }, _react.default.createElement(_core.IconButton, {
       "aria-label": "Search",
+      className: classes.iconButton,
       onClick: onSearch
     }, _react.default.createElement(_Search.default, {
       className: classes.icon

--- a/dist/nodes/SearchBar/style.js
+++ b/dist/nodes/SearchBar/style.js
@@ -41,6 +41,9 @@ var _default = (0, _styles.makeStyles)(function (theme) {
     }, _defineProperty(_input, "fontSize", 14.2), _defineProperty(_input, "letterSpacing", 0.25), _defineProperty(_input, "lineHeight", 20), _input),
     icon: {
       color: 'rgba(44,62,80,0.54)'
+    },
+    iconButton: {
+      padding: theme.spacing(1.5)
     }
   };
 });

--- a/src/lib/nodes/SearchBar/index.jsx
+++ b/src/lib/nodes/SearchBar/index.jsx
@@ -48,6 +48,7 @@ const Search = ({ onEnter, placeholder, value, onChange, disabled }) => {
           <InputAdornment position="end">
             <IconButton
                   aria-label="Search"
+                  className={classes.iconButton} 
                   onClick={onSearch}
                 >
                   <SearchIcon className={classes.icon} />

--- a/src/lib/nodes/SearchBar/style.js
+++ b/src/lib/nodes/SearchBar/style.js
@@ -32,5 +32,8 @@ export default makeStyles(theme => ({
   },
   icon: {
     color: 'rgba(44,62,80,0.54)'
+  },
+  iconButton: {
+    padding: theme.spacing(1.5),
   }
 }));


### PR DESCRIPTION
### Description
- Fixing padding in search icon button.

Fixes # [ISSUE]

### Type of Change:
**Delete irrelevant options.**

- User Interface



### How Has This Been Tested?
Local.


### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project

### Antes
<img width="1266" alt="Screen Shot 2021-12-06 at 17 08 37" src="https://user-images.githubusercontent.com/79170332/144937389-81d36adc-6edd-4e75-8abb-265f69f68e0c.png">

### Ahora
<img width="1261" alt="Screen Shot 2021-12-06 at 17 09 00" src="https://user-images.githubusercontent.com/79170332/144937409-23cb7462-5593-4e13-8204-1f5abdfd2930.png">

