### PR TITLE
disable add, drag and drop in read-only documents

### DIFF
--- a/dist/FileFinder/Drag/index.js
+++ b/dist/FileFinder/Drag/index.js
@@ -29,7 +29,8 @@ var Drag = function Drag(_ref) {
       moveCard = _ref.moveCard,
       handleOnClick = _ref.handleOnClick,
       selected = _ref.selected,
-      dragType = _ref.dragType;
+      dragType = _ref.dragType,
+      enableDragDrop = _ref.enableDragDrop;
 
   var dropMonitor = function dropMonitor(item, monitor) {
     var dragIndex = monitor.getItem().index;
@@ -47,6 +48,9 @@ var Drag = function Drag(_ref) {
     return {
       accept: dragType,
       drop: dropMonitor,
+      canDrop: function canDrop(item, monitor) {
+        return enableDragDrop;
+      },
       collect: function collect(monitor) {
         return {
           canDrop: !!monitor.canDrop()
@@ -88,7 +92,8 @@ Drag.propTypes = {
   index: _propTypes.default.number.isRequired,
   selected: _propTypes.default.bool,
   handleOnClick: _propTypes.default.func,
-  dragType: _propTypes.default.string
+  dragType: _propTypes.default.string,
+  enableDragDrop: _propTypes.default.bool
 };
 Drag.defaultProps = {
   file: new File([''], '', {
@@ -96,7 +101,8 @@ Drag.defaultProps = {
   }),
   selected: false,
   handleOnClick: function handleOnClick() {},
-  dragType: 'file'
+  dragType: 'file',
+  enableDragDrop: false
 };
 var _default = Drag;
 exports.default = _default;

--- a/dist/FileFinder/index.js
+++ b/dist/FileFinder/index.js
@@ -82,9 +82,10 @@ var FileFinder = function FileFinder(_ref) {
       index: index,
       moveCard: moveCard,
       handleOnClick: handleOnClick,
-      selected: index === current
+      selected: index === current,
+      enableDragDrop: !disabled
     }))));
-  }), _react.default.createElement(_Grid.default, {
+  }), !disabled && _react.default.createElement(_Grid.default, {
     item: true,
     sm: 3
   }, _react.default.createElement(_Add.default, {

--- a/dist/FilePreview/index.js
+++ b/dist/FilePreview/index.js
@@ -41,8 +41,6 @@ var FilePreview = function FilePreview(_ref) {
       onDownloadFile = _ref.onDownloadFile,
       disabled = _ref.disabled,
       urlDocument = _ref.urlDocument;
-  console.log('esto es antesx');
-  console.log(file);
   var clasess = (0, _style.default)();
 
   var _useState = (0, _react.useState)(''),
@@ -51,8 +49,6 @@ var FilePreview = function FilePreview(_ref) {
       setUrl = _useState2[1];
 
   var readFile = function readFile() {
-    console.log('lol');
-    console.log(file);
     var reader = new FileReader();
 
     reader.onloadend = function () {

--- a/src/lib/FileFinder/Drag/index.jsx
+++ b/src/lib/FileFinder/Drag/index.jsx
@@ -5,7 +5,7 @@ import { useDrag } from 'react-dnd'
 import { useDrop } from 'react-dnd';
 import FileThumbnail from '../../FileThumbnail';
 
-const Drag = ({ file, index, moveCard, handleOnClick, selected, dragType }) => {
+const Drag = ({ file, index, moveCard, handleOnClick, selected, dragType, enableDragDrop }) => {
   const dropMonitor = (item, monitor) => {
     
     const dragIndex = monitor.getItem().index;
@@ -24,6 +24,7 @@ const Drag = ({ file, index, moveCard, handleOnClick, selected, dragType }) => {
     () => ({
       accept: dragType,
       drop: dropMonitor,
+      canDrop: (item, monitor) => enableDragDrop,
       collect: (monitor) => ({
         canDrop: !!monitor.canDrop()
       })
@@ -58,6 +59,7 @@ Drag.propTypes = {
   selected: PropTypes.bool,
   handleOnClick: PropTypes.func,
   dragType: PropTypes.string,
+  enableDragDrop: PropTypes.bool,
 };
 
 Drag.defaultProps = {
@@ -65,6 +67,7 @@ Drag.defaultProps = {
   selected: false,
   handleOnClick: () => {},
   dragType: 'file',
+  enableDragDrop: false,
 };
 
 export default Drag;

--- a/src/lib/FileFinder/index.jsx
+++ b/src/lib/FileFinder/index.jsx
@@ -62,19 +62,23 @@ const FileFinder = ({
                       moveCard={moveCard}
                       handleOnClick={handleOnClick}
                       selected={index === current}
+                      enableDragDrop={!disabled}
                     />
                   </div>
                 </Flipped>
               </Grid>
             ))
           }
-            <Grid item sm={3}>
-              <Add 
-                multiple={multiple}
-                accept={accept}
-                onDrop={onDrop}
-              />
-            </Grid>
+            { !disabled && (
+              <Grid item sm={3}>
+                <Add 
+                  multiple={multiple}
+                  accept={accept}
+                  onDrop={onDrop}
+                />
+              </Grid>
+              )
+            } 
         </Grid>
       </Flipper>
     </DndProvider>

--- a/src/lib/FilePreview/index.jsx
+++ b/src/lib/FilePreview/index.jsx
@@ -12,14 +12,10 @@ import { PdfViewer } from '../nodes';
 import DetectPdf from '../nodes/PdfViewer/detectPdf';
 
 const FilePreview = ({ file, onDelete, onDownloadFile, disabled, urlDocument }) => {
-  console.log('esto es antesx');
-    console.log(file);
   const clasess = useStyles();
   const [url, setUrl] = useState('');
 
   const readFile = () => {
-    console.log('lol');
-    console.log(file);
     const reader  = new FileReader();
     reader.onloadend = function () {
       const _url = URL.createObjectURL(file);

--- a/src/lib/UploadDocuments/index.jsx
+++ b/src/lib/UploadDocuments/index.jsx
@@ -27,7 +27,7 @@ const UploadDocuments = ({
   placeholder,
   url,
   disabled,
-  required
+  required,
 }) => {
   const classes = useStyles();
   const [file, setFile] = useState(null);


### PR DESCRIPTION
### Description
disable add, drag and drop in read-only documents

Fixes # [ISSUE]

### Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Local.


### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 

<img width="937" alt="Screen Shot 2022-01-11 at 19 26 27" src="https://user-images.githubusercontent.com/79170332/149047523-29dc2c72-d638-40a6-8d9a-52c5d7ccb84d.png">

