### PR TITLE
missing styles in FileThumbnail

### DIFF
--- a/dist/FileThumbnail/style.js
+++ b/dist/FileThumbnail/style.js
@@ -24,6 +24,9 @@ var useStyles = (0, _styles.makeStyles)(function (theme) {
       border: 'solid 1px #E0E0E0',
       borderRadius: '4px'
     },
+    isOver: {
+      border: "1px dashed ".concat(theme.palette.primary.main)
+    },
     image: {
       width: '100%',
       height: '100%',


### PR DESCRIPTION
### Description
- missing styles to show border in a drop document.

Fixes # [ISSUE]

### Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
Local.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
